### PR TITLE
classnames import typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -685,7 +685,7 @@ class Button extends Component {
 
 ```jsx
 // good
-import cx from 'classnames';
+import classNames from 'classnames';
  
 class Button extends Component {
   // ... 


### PR DESCRIPTION
In the [classnames section.](https://github.com/iraycd/React-Redux-Styleguide#react-styles--use_classnames)

classnames is imported as **cx** while in the code we use **classNames**.